### PR TITLE
Fix json for humidity sensor

### DIFF
--- a/software/NRG_itho_wifi/10_Gen_func.ino
+++ b/software/NRG_itho_wifi/10_Gen_func.ino
@@ -199,7 +199,7 @@ void updateSensor() {
     
     if (mqttClient.connected() && updated) {
       char buffer[512];
-      sprintf(buffer, "{\"temp\":\"%1.1f\";\"hum\":\"%1.1f\"}", ithoTemp, ithoHum);
+      sprintf(buffer, "{\"temp\":%1.1f,\"hum\":%1.1f}", ithoTemp, ithoHum);
       char topicBuf[128 + 16] = "";
       strcpy(topicBuf, systemConfig.mqtt_state_topic);
       strcat(topicBuf, "/sensor");


### PR DESCRIPTION
Hi Arjen, I had trouble reading the json for the humidity sensor in Home-assistant. I noticed a semicolumn was used instead of a comma between the values and I removed the quotes around values.