### PR TITLE
Switch to percentages for HA Discovery support

### DIFF
--- a/software/NRG_itho_wifi/09_init_code.ino
+++ b/software/NRG_itho_wifi/09_init_code.ino
@@ -513,11 +513,10 @@ void HADiscoveryFan() {
   root["json_attr_t"] = (const char*)systemConfig.mqtt_sensor_topic;
   sprintf(s, "%s/not_used/but_needed_for_HA", systemConfig.mqtt_cmd_topic);
   root["cmd_t"] = s;
-  root["spd_cmd_t"] = (const char*)systemConfig.mqtt_cmd_topic;
-  root["spd_stat_t"] = (const char*)systemConfig.mqtt_state_topic;
-  root["payload_high_speed"] = systemConfig.itho_high;
-  root["payload_medium_speed"] = systemConfig.itho_medium;
-  root["payload_low_speed"] = systemConfig.itho_low;
+  root["pct_cmd_t"] = (const char*)systemConfig.mqtt_cmd_topic;
+  root["pct_cmd_tpl"] = "{{ value * 2.54 }}";  
+  root["pct_stat_t"] = (const char*)systemConfig.mqtt_state_topic;
+  root["pct_val_tpl"] = "{{ ((value | int) / 2.54) | round}}"";  
 
   sprintf(s, "%s/fan/%s/config" , (const char*)systemConfig.mqtt_ha_topic, hostName());
 

--- a/software/NRG_itho_wifi/09_init_code.ino
+++ b/software/NRG_itho_wifi/09_init_code.ino
@@ -516,7 +516,7 @@ void HADiscoveryFan() {
   root["pct_cmd_t"] = (const char*)systemConfig.mqtt_cmd_topic;
   root["pct_cmd_tpl"] = "{{ value * 2.54 }}";  
   root["pct_stat_t"] = (const char*)systemConfig.mqtt_state_topic;
-  root["pct_val_tpl"] = "{{ ((value | int) / 2.54) | round}}"";  
+  root["pct_val_tpl"] = "{{ ((value | int) / 2.54) | round}}";  
 
   sprintf(s, "%s/fan/%s/config" , (const char*)systemConfig.mqtt_ha_topic, hostName());
 


### PR DESCRIPTION
As Home Assistant deprecated the use of speeds and dropping support fully in the next release (https://rc.home-assistant.io/blog/2021/08/25/release-20219/#breaking-changes), the firmware needs to be updated to use percentages instead. Very basic implementation, removes the low/mid/high presets for now but should keep discovery of the ITHO-fan working. Not being able to test fully yet (no tools at hand for compiling the code) but working with manual MQTT-commands so it should do the trick. Happy to test if a HW1 firmware file is provided.

Should also close #28.  