### PR TITLE
Better humidity/temperature sensors in Home Assistant

### DIFF
--- a/software/NRG_itho_wifi/TaskMQTT.ino
+++ b/software/NRG_itho_wifi/TaskMQTT.ino
@@ -367,6 +367,7 @@ void HADiscoveryTemperature() {
   root["uniq_id"] = s;
   root["name"] = s;
   root["stat_t"] = (const char*)systemConfig.mqtt_ithostatus_topic;
+  root["stat_cla"] = "measurement";
   root["val_tpl"] = "{{ value_json.temp }}";
   root["unit_of_meas"] = "°C";
 
@@ -387,6 +388,7 @@ void HADiscoveryHumidity() {
   root["uniq_id"] = s;
   root["name"] = s;
   root["stat_t"] = (const char*)systemConfig.mqtt_ithostatus_topic;
+  root["stat_cla"] = "measurement";
   root["val_tpl"] = "{{ value_json.hum }}";
   root["unit_of_meas"] = "%";
 


### PR DESCRIPTION
This pull request proposes some minor tweaks to the MQTT Home Assistant discovery messages for humidity/temperature to make the sensors as displayed in HA nicer to use.

 - Add the unit to both sensors (°C/%). This will show the unit in any dashboard, and also change how the data is handled.
Instead of this card with a bar chart of unique values (?) :
![Humidity sensor entity card shown as it is now, with a horizontal bar chart with lots of colours for each unique value](https://user-images.githubusercontent.com/8148535/138558124-941448e9-44cd-4a21-9871-f247a4c7c919.png)
Home Assistant will now display a graph:
![Humidity sensor entity card shown as these changes are applied, now showing a graph of the percentage changing](https://user-images.githubusercontent.com/8148535/138558137-c7293e7d-594c-4645-9247-f438a43c7637.png)
In addition, you can easily show the data on a chart with another sensor on the history page. This will also prevent the values from showing up every 15 minutes in the logbook when using the default recorder settings. HA can now also convert the value for the temperature sensor to fahrenheit without any additional configuration.
- Enable long-term statistics for both sensors. HA will automatically generate [some](https://developers.home-assistant.io/blog/2021/05/25/sensor_attributes/) [numbers](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics) based on the data, which can be useful for automations.

I'm not sure how to compile the code so I didn't test this on the hardware, but adding new MQTT messages with these values did create the entities in HA as expected (also used for the screenshot).
This change should [update the existing sensors](https://www.home-assistant.io/docs/mqtt/discovery/#:~:text=Subsequent%20messages%20on%20a%20topic%20where%20a%20valid%20payload%20has%20been%20received%20will%20be%20handled%20as%20a%20configuration%20update), and the value of the entity exposed in HA isn't changed, so there shouldn't be any breaking changes for users.
