### PR TITLE
Fix unsigned floats

### DIFF
--- a/software/NRG_itho_wifi/src/IthoSystem.cpp
+++ b/software/NRG_itho_wifi/src/IthoSystem.cpp
@@ -701,7 +701,7 @@ void sendQueryStatusFormat(bool updateweb)
       ithoStatus.back().length = get_length_from_datatype(i2cbuf[6 + i]);
       ithoStatus.back().divider = get_divider_from_datatype(i2cbuf[6 + i]);
 
-      if (ithoStatus.back().divider == 1.)
+      if (ithoStatus.back().divider == 1)
       { // integer value
           ithoStatus.back().type = ithoDeviceStatus::is_int;
       }
@@ -1771,13 +1771,14 @@ int cast_to_signed_int(int val, int length)
 // bit 7: signed (1), unsigned (0)
 // bit 6,5,4 : length
 // bit 3,2,1,0 : divider
-float get_divider_from_datatype(int8_t datatype) {
+uint32_t get_divider_from_datatype(int8_t datatype) {
 
-  const float _divider[] =
+  const uint32_t _divider[] =
   {
-    1., 10., 100., 1000., 1E+4, 1E+5,
-    1E+6, 1E+7, 1E+8, 0.1, 0.01,
-    1., 1., 1., 256., 2.
+    1, 10, 100, 1000, 10000, 100000,
+    1000000, 10000000, 100000000,
+    1, 1,  // dividers index 9 and 10 should be 0.1 and 0.01
+    1, 1, 1, 256, 2
   };
   return _divider[datatype & 0x0f];
 }

--- a/software/NRG_itho_wifi/src/IthoSystem.h
+++ b/software/NRG_itho_wifi/src/IthoSystem.h
@@ -59,6 +59,7 @@ struct ithoDeviceStatus
   } value;
   uint32_t divider;
   uint8_t updated;
+  bool is_signed;  // used for floats only
   ithoDeviceStatus() : updated(0){};
 };
 
@@ -146,3 +147,4 @@ void filterReset();
 void IthoPWMcommand(uint16_t value, volatile uint16_t *ithoCurrentVal, bool *updateIthoMQTT);
 int quick_pow10(int n);
 std::string i2cbuf2string(const uint8_t *data, size_t len);
+int cast_to_signed_int(int val, int length);

--- a/software/NRG_itho_wifi/src/IthoSystem.h
+++ b/software/NRG_itho_wifi/src/IthoSystem.h
@@ -56,9 +56,9 @@ struct ithoDeviceStatus
     double floatval;
     const char *stringval;
   } value;
-  float divider;
+  uint32_t divider;
   uint8_t updated;
-  bool is_signed;  // used for floats only
+  bool is_signed;
   ithoDeviceStatus() : updated(0){};
 };
 

--- a/software/NRG_itho_wifi/src/IthoSystem.h
+++ b/software/NRG_itho_wifi/src/IthoSystem.h
@@ -44,7 +44,6 @@ struct ithoDeviceStatus
   {
     is_byte,
     is_int,
-    is_uint,
     is_float,
     is_string
   } type;
@@ -57,7 +56,7 @@ struct ithoDeviceStatus
     double floatval;
     const char *stringval;
   } value;
-  uint32_t divider;
+  float divider;
   uint8_t updated;
   bool is_signed;  // used for floats only
   ithoDeviceStatus() : updated(0){};
@@ -148,3 +147,6 @@ void IthoPWMcommand(uint16_t value, volatile uint16_t *ithoCurrentVal, bool *upd
 int quick_pow10(int n);
 std::string i2cbuf2string(const uint8_t *data, size_t len);
 int cast_to_signed_int(int val, int length);
+float get_divider_from_datatype(int8_t datatype);
+uint8_t get_length_from_datatype(int8_t datatype);
+bool get_signed_from_datatype(int8_t datatype);

--- a/software/NRG_itho_wifi/src/IthoSystem.h
+++ b/software/NRG_itho_wifi/src/IthoSystem.h
@@ -147,6 +147,6 @@ void IthoPWMcommand(uint16_t value, volatile uint16_t *ithoCurrentVal, bool *upd
 int quick_pow10(int n);
 std::string i2cbuf2string(const uint8_t *data, size_t len);
 int cast_to_signed_int(int val, int length);
-float get_divider_from_datatype(int8_t datatype);
+uint32_t get_divider_from_datatype(int8_t datatype);
 uint8_t get_length_from_datatype(int8_t datatype);
 bool get_signed_from_datatype(int8_t datatype);

--- a/software/NRG_itho_wifi/src/generic_functions.cpp
+++ b/software/NRG_itho_wifi/src/generic_functions.cpp
@@ -79,10 +79,6 @@ void getIthoStatusJSON(JsonObject root)
       {
         root[ithoStat.name] = ithoStat.value.byteval;
       }
-      else if (ithoStat.type == ithoDeviceStatus::is_uint)
-      {
-        root[ithoStat.name] = ithoStat.value.uintval;
-      }
       else if (ithoStat.type == ithoDeviceStatus::is_int)
       {
         root[ithoStat.name] = ithoStat.value.intval;


### PR DESCRIPTION
Fixes #123 

This is a bit of a hack, as it implements a "is_signed" flag for "floats" but leaves ints and uints in place.
In reality all "itho raw bytes" are either signed/unsigned and have some divider. Ints are just floats with divider 1.

This should be refactored with `IthoDeviceStatus::type`  (int/uints/float) removed and only the `is_signed` flag in place.
 
But this works:


Cast "signed raw bytes" to signed integer first, before casting to float and applying a divider.

Example: datatype = 0x92 (1-0-010-010)
datatype & 0x80 (bit 8) => signed value
datatype & 0x38 (bits 654) => length => 2 bytes
datatype & 0x07 (bits 321) => divider => 10^2

datatype 0x92 value 0xFC18
datatype signed, length 2, divider 100.
signed int value -1000: value -10.00