### PR TITLE
Check if i2c reply is 31DA

### DIFF
--- a/software/NRG_itho_wifi/src/IthoSystem.cpp
+++ b/software/NRG_itho_wifi/src/IthoSystem.cpp
@@ -937,9 +937,8 @@ void sendQuery31DA(bool updateweb)
   uint8_t i2cbuf[512]{};
   size_t len = i2c_slave_receive(i2cbuf);
 
-  if (len > 1 && i2cbuf[len - 1] == checksum(i2cbuf, len - 1))
+  if (len > 1 && i2cbuf[len - 1] == checksum(i2cbuf, len - 1) && i2cbuf[3] == 0x31 && i2cbuf[4] == 0xDA)
   {
-
     if (updateweb)
     {
       updateweb = false;


### PR DESCRIPTION
Fixes #131 

THIS IS UNTESTED as I only have non-CVE devices which do not transmit 31DA.

DO NOT MERGE ;-) 

On non-CVE systems (WPU) there can be considerable i2c traffic. After a 31DA request, we cannot be certain that the next message is a 31DA reply. (On non-CVE systems it will never be a 31DA) Check if reply is 31DA to prevent incorrectly reading a random message as 31DA content.