### PR TITLE
Improve version in Home Assistant MQTT discovery

### DIFF
--- a/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
@@ -556,8 +556,8 @@ void addHADevInfo(JsonObject obj)
   dev["model"] = "ITHO Wifi Add-on";
   snprintf(s, sizeof(s), "ITHO-WIFI(%s)", hostName());
   dev["name"] = s;
-  snprintf(s, sizeof(s), "HW: v%s, FW: %s", hw_revision, FWVERSION);
-  dev["sw_version"] = s;
+  dev["hw_version"] = hw_revision;
+  dev["sw_version"] = FWVERSION;
 }
 
 void sendHADiscovery(JsonObject obj, const char *topic)


### PR DESCRIPTION
Home Assistant 2022.9 made it possible to provide a separate hardware version in MQTT discovery messages. This PR updates the auto discovery information to make use of this.

|Before|After|
|-----|-----|
|![Device info card in Home Assistant: 'ITHO Wifi Add-on', 'by Arjen Hiemstra', 'Firmware: HW: v2, FW: 2.5.0'](https://user-images.githubusercontent.com/8148535/219965895-1fa9c325-bb8e-413d-b6fa-8d62aea1d6ef.png)|![Device info card in Home Assistant: 'ITHO Wifi Add-on', 'by Arjen Hiemstra', 'Firmware: 2.5.0', 'Hardware: 2'](https://user-images.githubusercontent.com/8148535/219965923-49bea6c0-bd75-4944-ae5d-25bc82d2f05a.png)|
