### PR TITLE
Expose the last command time in the get=remotesinfo API call

### DIFF
--- a/software/NRG_itho_wifi/main/cc1101/IthoCC1101.cpp
+++ b/software/NRG_itho_wifi/main/cc1101/IthoCC1101.cpp
@@ -1088,6 +1088,7 @@ bool IthoCC1101::removeRFDevice(uint32_t ID)
       //      strlcpy(item.name, "", sizeof(item.name));
       item.remType = RemoteTypes::UNSETTYPE;
       item.lastCommand = IthoUnknown;
+      item.timestamp = (time_t)0;
       item.co2 = 0xEFFF;
       item.temp = 0xEFFF;
       item.hum = 0xEFFF;
@@ -1279,11 +1280,15 @@ void IthoCC1101::handleLevel()
     }
   }
 
+  time_t now;
+  time(&now);
+
   for (auto &item : ithoRF.device)
   {
     if (item.deviceId == tempID)
     {
       item.lastCommand = inIthoPacket.command;
+      item.timestamp = now;
     }
   }
 }
@@ -1350,11 +1355,15 @@ void IthoCC1101::handleTimer()
     }
   }
 
+  time_t now;
+  time(&now);
+
   for (auto &item : ithoRF.device)
   {
     if (item.deviceId == tempID)
     {
       item.lastCommand = inIthoPacket.command;
+      item.timestamp = now;
     }
   }
 }

--- a/software/NRG_itho_wifi/main/cc1101/IthoCC1101.h
+++ b/software/NRG_itho_wifi/main/cc1101/IthoCC1101.h
@@ -18,6 +18,7 @@ struct ithoRFDevice
   RemoteTypes remType;
   //  char name[16];
   IthoCommand lastCommand{IthoUnknown};
+  time_t timestamp;
   int32_t co2{0xEFFF};
   int32_t temp{0xEFFF};
   int32_t hum{0xEFFF};

--- a/software/NRG_itho_wifi/main/tasks/task_cc1101.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_cc1101.cpp
@@ -402,6 +402,7 @@ void TaskCC1101(void *pvParameters)
             int remIndex = remotes.remoteIndex(item.deviceId);
             if (remIndex != -1)
             {
+              remotes.addCapabilities(remIndex, "timestamp", item.timestamp);
               remotes.addCapabilities(remIndex, "lastcmd", item.lastCommand);
               if (item.co2 != 0xEFFF)
               {


### PR DESCRIPTION
This makes it easier for automation software to detect state changes, and figure out when they occurred. See https://github.com/arjenhiemstra/ithowifi/issues/157 for more details.