### PR TITLE
Support Nginx proxy

### DIFF
--- a/software/NRG_itho_wifi/main/webroot_source/controls.js
+++ b/software/NRG_itho_wifi/main/webroot_source/controls.js
@@ -8,8 +8,8 @@ var sensor = -1;
 
 sessionStorage.setItem("statustimer", 0);
 var settingIndex = -1;
-
-var websocketServerLocation = 'ws://' + window.location.hostname + ':8000/ws';
+ 
+var websocketServerLocation = location.protocol === 'https' ? 'wss://' + window.location + ':8000/ws' : 'ws://' + window.location.hostname + ':8000/ws';
 
 function startWebsock(websocketServerLocation) {
   console.log(websocketServerLocation);


### PR DESCRIPTION
Add support for an NGINX proxy 

NGINX config :
upstream websocket{
	server localipaddres:8000; 
	#SERVER endpoint that handle ws:// connections
}

server {
	#handle normal HTTPs traffic
	listen 443 ssl http2;
	server_name XXXXX.server.com;

	location / {
		proxy_pass http://localipaddres;
		proxy_set_header Host $host;
		proxy_redirect http:// https://;
		proxy_http_version 1.1;
		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
		proxy_set_header Upgrade $http_upgrade;
		proxy_set_header Connection $connection_upgrade;
	}
}

server {
	#handle normal wss traffic
	listen 8000 ssl http2;
    server_name XXXXX.server.com;
	location / {
		proxy_pass http://websocket;
		proxy_http_version 1.1;
		proxy_set_header Upgrade $http_upgrade;
		proxy_set_header Connection "Upgrade";
	}
}