### PR TITLE
Updated HA MQTT autodiscovery to match WiKi

### DIFF
--- a/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
@@ -500,15 +500,15 @@ void HADiscoveryFan()
   root["pr_mode_stat_t"] = (const char *)systemConfig.mqtt_state_topic;
   root["pr_mode_val_tpl"] =
     "{%- set valuepct = 100*(value | int)/255|round(0) %}"
-    "{%- if valuepct >= 20 and valuepct <= 27 %}Low"
-    "{%- elif valuepct >= 46 and valuepct <= 53 %}Medium"
-    "{%- elif valuepct >= 77 and valuepct <= 83 %}High"
+    "{%- if valuepct >= " + String(systemConfig.itho_low - 5) + " and valuepct <= " + String(systemConfig.itho_low + 5) + " %}Low"
+    "{%- elif valuepct >= " + String(systemConfig.itho_medium - 5) + " and valuepct <= " + String(systemConfig.itho_medium + 5) + " %}Medium"
+    "{%- elif valuepct >= " + String(systemConfig.itho_high - 5) + " and valuepct <= " + String(systemConfig.itho_high + 5) + " %}High"
     "{%- elif valuepct >= 97 %}Max{% endif -%}";
   root["pr_mode_cmd_t"] = (const char *)systemConfig.mqtt_cmd_topic;
   root["pr_mode_cmd_tpl"] =
-    "{%- if value == 'Low' %}{{(25*255/100)|round(0)}}"
-    "{%- elif value == 'Medium' %}{{(50*255/100)|round(0)}}"
-    "{%- elif value == 'High' %}{{(80*255/100)|round(0)}}"
+    "{%- if value == 'Low' %}{{(" + String(systemConfig.itho_low) + "*255/100)|round(0)}}"
+    "{%- elif value == 'Medium' %}{{(" + String(systemConfig.itho_medium) + "*255/100)|round(0)}}"
+    "{%- elif value == 'High' %}{{(" + String(systemConfig.itho_high) + "*255/100)|round(0)}}"
     "{%- elif value == 'Max' %}{{(100*255/100)|round(0)}}"
     "{%- endif -%}";
 


### PR DESCRIPTION
The HA autodiscovery could have some more attributes to implement better with HA and to match the WiKi.
Timers aren't implemented since the preset does not trigger the Itho timer.

Old MQTT config:
```YAML
{
    "dev": {
        "identifiers": "nrg-itho-XXXX",
        "manufacturer": "Arjen Hiemstra",
        "model": "ITHO Wifi Add-on",
        "name": "ITHO-WIFI(nrg-itho-acb4)",
        "hw_version": "2",
        "sw_version": "2.5.6"
    },
    "avty_t": "itho/lwt",
    "uniq_id": "nrg-itho-XXXX_fan",
    "name": "nrg-itho-XXXX_fan",
    "stat_t": "itho/lwt",
    "stat_val_tpl": "{% if value == 'online' %}ON{% else %}OFF{% endif %}",
    "json_attr_t": "itho/ithostatus",
    "cmd_t": "itho/cmd/not_used/but_needed_for_HA",
    "pct_cmd_t": "itho/cmd",
    "pct_cmd_tpl": "{{ value * 2.54 }}",
    "pct_stat_t": "itho/state",
    "pct_val_tpl": "{{ ((value | int) / 2.54) | round}}"
}
```

New MQTT config:
```YAML
{
    "dev": {
        "identifiers": "nrg-itho-XXXX",
        "manufacturer": "Arjen Hiemstra",
        "model": "ITHO Wifi Add-on",
        "name": "ITHO-WIFI(nrg-itho-acb4)",
        "hw_version": "2",
        "sw_version": "2.5.6"
    },
    "avty_t": "itho/lwt",
    "uniq_id": "nrg-itho-xxxx_fan",
    "name": "nrg-itho-xxxx_fan",
    "stat_t": "itho/state",
    "stat_val_tpl": "{% if (value | int) > 0 %}ON{% else %}OFF{% endif %}",
    "json_attr_t": "itho/ithostatus",
    "cmd_t": "itho/cmd",
    "cmd_tpl": "{% if value == 'OFF' %}{ 'speed':'0' }{% else %}{ 'command':'low' }{% endif %}",
    "pct_cmd_t": "itho/cmd",
    "pct_cmd_tpl": "{{ value * 2.54 }}",
    "pct_stat_t": "itho/state",
    "pct_val_tpl": "{{ ((value | int)*100/255) | round(0) }}",
    "pr_mode_stat_t": "itho/state",
    "pr_mode_val_tpl": "{%- set valuepct = 100*(value | int)/255|round(0) %}{%- if valuepct >= 20 and valuepct <= 27 %}Low{%- elif valuepct >= 46 and valuepct <= 53 %}Medium{%- elif valuepct >= 77 and valuepct <= 83 %}High{%- elif valuepct >= 97 %}Max{% endif -%}",
    "pr_mode_cmd_t": "itho/cmd",
    "pr_mode_cmd_tpl": "{%- if value == 'Low' %}{{(25*255/100)|round(0)}}{%- elif value == 'Medium' %}{{(50*255/100)|round(0)}}{%- elif value == 'High' %}{{(80*255/100)|round(0)}}{%- elif value == 'Max' %}{{(100*255/100)|round(0)}}{%- endif -%}",
    "pr_modes": [
        "Low",
        "Medium",
        "High",
        "Max"
    ]
}
```