### PR TITLE
fix: Enable state_value_template in Home Assistant discovery

### DIFF
--- a/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
@@ -581,8 +581,8 @@ add:
   snprintf(s, sizeof(s), "%s_fan", hostName());
   root["uniq_id"] = s;
   root["name"] = "fan";
-  // root["stat_t"] = static_cast<const char *>(statetopic);
-  // root["stat_val_tpl"] = "{% if value == '0' %}OFF{% else %}ON{% endif %}";
+  root["stat_t"] = static_cast<const char *>(statetopic);
+  root["stat_val_tpl"] = "{% if value == '0' %}OFF{% else %}ON{% endif %}";
   root["json_attr_t"] = static_cast<const char *>(ihtostatustopic);
   snprintf(s, sizeof(s), "%s/not_used/but_needed_for_HA", static_cast<const char *>(cmdtopic));
   root["cmd_t"] = s;


### PR DESCRIPTION
By setting a `state_value_template`, the "Unknown" state issue in Home Assistant (as also recently discussed in https://gathering.tweakers.net/forum/list_messages/1976492) disappears as Home Assistant will always have a way to determine the current on/off state.