### PR TITLE
Merge WPU manual control from fork

### DIFF
--- a/software/NRG_itho_wifi/main/IthoSystem.cpp
+++ b/software/NRG_itho_wifi/main/IthoSystem.cpp
@@ -1450,7 +1450,7 @@ void setSettingCE30(uint16_t temporary_temperature, uint16_t fallback_temperatur
   }
 }
 
-void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t checked, bool dryrun, bool updateweb)
+void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t checked, bool updateweb)
 {
   uint8_t command[] = {0x82,0x80,0x40,0x30,0x06,0x07,0x01,0x00,0x0F,0x00,0x01,0x01,0x01,0xFF};
   
@@ -1465,11 +1465,10 @@ void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t ch
   command[12] = checked & 0xFF;
 
   command[sizeof(command) - 1] = checksum(command, sizeof(command) - 1);
+
+  D_LOG("Sending 4030: %s", i2cbuf2string(command, sizeof(command)).c_str());
+  if (updateweb) jsonSysmessage("itho_4030_result", i2cbuf2string(command, sizeof(command)).c_str());
   
-  if (dryrun) {
-    jsonSysmessage("itho_4030_i2c_command", i2cbuf2string(command, sizeof(command)).c_str());
-    return;
-  }
   if (!i2c_sendBytes(command, sizeof(command), I2C_CMD_SET_CE30))
   {
     if (updateweb)
@@ -1480,10 +1479,6 @@ void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t ch
     return;
   } 
 }
-
-
-
-
 
 int32_t *sendQuery2410(uint8_t index, bool updateweb)
 {

--- a/software/NRG_itho_wifi/main/IthoSystem.h
+++ b/software/NRG_itho_wifi/main/IthoSystem.h
@@ -137,7 +137,7 @@ void sendQueryStatus(bool updateweb);
 void sendQuery31DA(bool updateweb);
 void sendQuery31D9(bool updateweb);
 void setSettingCE30(uint16_t temporary_temperature, uint16_t fallback_temperature, uint32_t timestamp, bool updateweb);
-void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t checked, bool dryrun, bool updateweb);
+void setSetting4030(uint16_t index, uint8_t datatype, uint16_t value, uint8_t checked, bool updateweb);
 int32_t *sendQuery2410(uint8_t index, bool updateweb);
 bool decodeQuery2410(int32_t *, ithoSettings *, double *, double *, double *);
 bool setSetting2410(uint8_t index, int32_t value, bool updateweb);

--- a/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
@@ -433,10 +433,8 @@ void mqttCallback(const char *topic, const byte *payload, unsigned int length)
         uint8_t datatype = root["manual_operation_datatype"].as<uint8_t>();
         uint16_t value = root["manual_operation_value"].as<uint16_t>();
         uint8_t checked = root["manual_operation_checked"].as<uint8_t>();
-        bool dryrun = root["manual_operation_dryrun"].as<bool>();
-        D_LOG("Manual operation MQTT. Dryrun: %d", dryrun);
         D_LOG("index: %d dt: %d value: %d checked: %d", index, datatype, value, checked);
-        setSetting4030(index, datatype, value, checked, dryrun, false);
+        setSetting4030(index, datatype, value, checked, false);
       }
       if (!jsonCmd)
       {

--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
@@ -289,12 +289,17 @@ Unless specified otherwise:<br>
                     example json:<br>
                     "{"manual_operation_index":1, "manual_operation_datatype":1,
                     "manual_operation_value": 1, "manual_operation_checked":1}"<br><br>
-                    info: missing keys or incorrect data will default to the value 0.
-
-                    index = 1 : asdf
-                    index = 2 : asdf
-                    etc.
-
+                    info: missing keys or incorrect data will default to the value 0.<br>
+                    <br>
+                    index = 0 : Outside temperature <br>
+                    index = 15 : High/low tariff. (0/1) (Force boiler on at low tariff) <br>
+                    index = 20 : Source pump speed (0-100) <br>
+                    index = 30 : Max relative modulation level (0-100) (total heat demand, force/block heating) <br>
+                    index = 31 : Electric element release (0/1) <br>
+                    index = 32 : CH (heating) released (0/1) <br>
+                    index = 33 : Cooling mode released (0/1) <br>
+                    index = 36 : Release tap water (boiler). 0=Eco. 2=Comfort. 3=Blocked. <br>
+                    index = 37 : Reset all faults. <br>
                 </em>
             </td>
         </tr>

--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
@@ -262,7 +262,42 @@ Unless specified otherwise:<br>
                     passed it will fallback to <b>outside_temp</b>.
                 </em></td>
         </tr>
+        <tr>
+            <td>manual control</td>
+            <td>json</td>
+            <td>see comments</td>
+            <td>json</td>
+            <td style="text-align:center">●</td>
+            <td style="text-align:center">◌</td>
+        </tr>
+        <tr>
+            <td colspan="6">
+                Comments:<br>
+                <em>
+                    Warning!!
+                    Manual control ie. the 4030 command is low level "manual control" of your itho unit.
+                    Use with care and use only if you know what you are doing!
+                    WPU 5G: Make sure you set the "Max manual operation time" setting in the settings page.
+                    The itho unit will remain in manual mode until the timer expires. 0 means unlimited.
+                    <br>
+                    <br>
+                    json keys explaination:<br>
+                    "manual_operation_index": manual_operation_index description (dataype uint16_t)<br>
+                    "manual_operation_datatype": manual_operation_datatype description (dataype uint8_t)<br>
+                    "manual_operation_value": manual_operation_value description (dataype uint16_t)<br>
+                    "manual_operation_checked": manual_operation_checked description (dataype uint8_t)<br><br>
+                    example json:<br>
+                    "{"manual_operation_index":1, "manual_operation_datatype":1,
+                    "manual_operation_value": 1, "manual_operation_checked":1}"<br><br>
+                    info: missing keys or incorrect data will default to the value 0.
 
+                    index = 1 : asdf
+                    index = 2 : asdf
+                    etc.
+
+                </em>
+            </td>
+        </tr>
         <tr>
             <td colspan="6"><b>Commands only for devices with CC1101 module</b></td>
         </tr>

--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_debug.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_debug.html
@@ -97,7 +97,8 @@
 
                 <button id="ithobutton-10D0" class="pure-button pure-button-primary">Filter
                     reset</button><br><span>Filter
-                    reset function uses virtual remote 0, this remote needs to be paired with your Itho unit for this command
+                    reset function uses virtual remote 0, this remote needs to be paired with your Itho unit for this
+                    command
                     to
                     work</span><br><br>
                 <button id="button4210" class="pure-button pure-button-primary">Query
@@ -112,8 +113,8 @@
                 <span>Result:&nbsp;</span><span id="itho_ce30_result"></span><br>
                 <br>
                 <span style="color:red">Warning!!<br>
-                4030 is low level "manual control" of your itho unit.<br>
-                Use with care and use only if you know what you are doing!</span><br>
+                    4030 is low level "manual control" of your itho unit.<br>
+                    Use with care and use only if you know what you are doing!</span><br>
                 <button id="button4030" class="pure-button pure-button-primary">Set 4030 Manual Control</button>
                 Index: <input id="itho_4030_index" type="text" size="5">
                 Datatype: <input id="itho_4030_datatype" type="text" size="5">
@@ -122,9 +123,9 @@
                 Password: "thisisunsafe": <input id="itho_4030_password" type="string" size="15"><br>
                 <span>Result:&nbsp;</span><span id="itho_4030_result"></span><br>
                 <span style="color:red">
-                WPU 5G: Make sure you set the "Max manual operation time" setting in the settings page.<br>
-                The itho unit will remain in manual mode until the timer expires. 0 means unlimited.<br>
-                Warning!!<br></vr></span><br>
+                    WPU 5G: Make sure you set the "Max manual operation time" setting on the "Itho settings" page.<br>
+                    The itho unit will remain in manual mode until the timer expires. 0 means unlimited.<br>
+                    Warning!!<br></vr></span><br>
             </fieldset><br><br><br>
         </fieldset>
     </form>

--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_debug.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_debug.html
@@ -110,6 +110,21 @@
                 Valid until(timestamp) <input id="itho_ce30_timestamp" type="number" min="0" max="2147483647" size="12"
                     value="0"><br>
                 <span>Result:&nbsp;</span><span id="itho_ce30_result"></span><br>
+                <br>
+                <span style="color:red">Warning!!<br>
+                4030 is low level "manual control" of your itho unit.<br>
+                Use with care and use only if you know what you are doing!</span><br>
+                <button id="button4030" class="pure-button pure-button-primary">Set 4030 Manual Control</button>
+                Index: <input id="itho_4030_index" type="text" size="5">
+                Datatype: <input id="itho_4030_datatype" type="text" size="5">
+                Value: <input id="itho_4030_value" type="text" size="5">
+                Checked: <input id="itho_4030_checked" ttype="text" size="2"><br>
+                Password: "thisisunsafe": <input id="itho_4030_password" type="string" size="15"><br>
+                <span>Result:&nbsp;</span><span id="itho_4030_result"></span><br>
+                <span style="color:red">
+                WPU 5G: Make sure you set the "Max manual operation time" setting in the settings page.<br>
+                The itho unit will remain in manual mode until the timer expires. 0 means unlimited.<br>
+                Warning!!<br></vr></span><br>
             </fieldset><br><br><br>
         </fieldset>
     </form>

--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/javascript.js
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/javascript.js
@@ -696,14 +696,15 @@ $(document).ready(function () {
       }));
     }
     else if ($(this).attr('id') == 'button4030') {
-      websock.send(JSON.stringify({
-        ithobutton: 4030,
-        idx: Number($('#itho_4030_index').val()),
-        dt: Number($('#itho_4030_datatype').val()),
-        val: Number($('#itho_4030_value').val()),
-        chk: Number($('#itho_4030_checked').val()),
-        dryrun: ($('#itho_4030_password').val() == 'thisisunsafe') ? false : true,
-      }));
+      if ($('#itho_4030_password').val() == 'thisisunsafe') {
+        websock.send(JSON.stringify({
+          ithobutton: 4030,
+          idx: Number($('#itho_4030_index').val()),
+          dt: Number($('#itho_4030_datatype').val()),
+          val: Number($('#itho_4030_value').val()),
+          chk: Number($('#itho_4030_checked').val()),
+        }));
+      }
     }
     else if ($(this).attr('id') == 'ithogetsettings') {
       if (localStorage.getItem("ihto_settings_complete") == "true" && localStorage.getItem("uuid") == uuid) {

--- a/software/NRG_itho_wifi/main/websocket.cpp
+++ b/software/NRG_itho_wifi/main/websocket.cpp
@@ -328,7 +328,7 @@ static void wsEvent(struct mg_connection *c, int ev, void *ev_data, void *fn_dat
           }
           else if (val == 4030)
           {
-            // setSetting4030(root["idx"].as<uint16_t>(), root["dt"].as<uint8_t>(), root["val"].as<int16_t>(), root["chk"].as<uint8_t>(), root["dryrun"].as<bool>(), true);
+            setSetting4030(root["idx"].as<uint16_t>(), root["dt"].as<uint8_t>(), root["val"].as<int16_t>(), root["chk"].as<uint8_t>(), true);
           }
         }
         else


### PR DESCRIPTION
This merges the changes in the private fork that enables "manual operation". It is mainly used for controlling the WPU heatpump.

This commit adds "4030 Manual control" to the debug page. The debug option "dryrun" is removed. It is no longer needed for initial debugging.


Ref: https://gathering.tweakers.net/forum/list_message/77786836#77786836

It seems to work, but I will do some more testing tomorrow, to make sure this actually works.

TODO:
 - [x] Test.
 - [x] Add documentation to wiki
 