### PR TITLE
Fix utc time for WPU

### DIFF
--- a/software/NRG_itho_wifi/main/IthoSystem.h
+++ b/software/NRG_itho_wifi/main/IthoSystem.h
@@ -52,7 +52,6 @@ struct ithoDeviceStatus
   {
     byte byteval;
     int32_t intval;
-    uint32_t uintval;
     double floatval;
     const char *stringval;
   } value;

--- a/software/NRG_itho_wifi/main/devices/wpu.h
+++ b/software/NRG_itho_wifi/main/devices/wpu.h
@@ -586,7 +586,7 @@ const struct ithoLabels ithoWPUStatusLabels[]{
     {"Error_retry", "error_retry"},
     {"Task active", "task-active"},
     {"UTC time", "utc-time"},
-    {"UTC time", "utc-time"},
+    {"UTC time valid", "utc-time-valid"},
     {"Element blocked during retry", "element-blocked-during-retry"},
     {"Spare input", "spare-input"},
     {"Electr element DHW blocked", "electr-element-dhw-blocked"},


### PR DESCRIPTION
Fixes #235 

This fixes the UTC time not being show on WPU 5G. (It turn out not be an uint32 being truncated or a JSON serialising thing, but a duplicate key in the WPU statuslables.

This also removes the field `uintval` in IthoSystem.h type `IthoDeviceStatus`.
The uintval field is actually never used and if used, handling of the value is not implemented.

Handling of int values (signed/unsigned) is probably not 100% bugfree. But at value "in the wild" seem to be handled fine.

