### PR TITLE
Fix typo in manual control API

### DIFF
--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
@@ -296,8 +296,8 @@ Unless specified otherwise:<br>
                     index = 20 : Source pump speed (0-100) <br>
                     index = 30 : Max relative modulation level (0-100) (total heat demand, force/block heating) <br>
                     index = 31 : Electric element release (0/1) <br>
-                    index = 32 : CH (heating) released (0/1) <br>
-                    index = 33 : Cooling mode released (0/1) <br>
+                    index = 33 : CH (heating) released (0/1) <br>
+                    index = 34 : Cooling mode released (0/1) <br>
                     index = 36 : Release tap water (boiler). 0=Eco. 2=Comfort. 3=Blocked. <br>
                     index = 37 : Reset all faults. <br>
                 </em>


### PR DESCRIPTION
This fixes a typo in the manual control API.
(The corresponding wiki page does not have the typo...)

Ref: https://gathering.tweakers.net/forum/view_message/78407940