### PR TITLE
Point link to unified hw2 and noncve Github folder

### DIFF
--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_update.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_update.html
@@ -62,12 +62,8 @@
 <script>
   $('#firmware_ver').text(fw_version);
   $('#hardware_rev').text(hw_revision);
-  if (hw_revision.startsWith('NON-CVE ')) {
-    $('#other_firmware').append('<a target="_blank" href="https://github.com/arjenhiemstra/ithowifi/tree/master/compiled_firmware_files/non-cve_rev_1">link</a>');
-  }
-  else if (hw_revision == '2') {
-    $('#other_firmware').append('<a target="_blank" href="https://github.com/arjenhiemstra/ithowifi/tree/master/compiled_firmware_files/hardware_rev_2">link</a>');
-  }
+  $('#other_firmware').append('<a target="_blank" href="https://github.com/arjenhiemstra/ithowifi/tree/master/compiled_firmware_files/unified_hw2_noncve">link</a>');
+  
   function process(key, value) {
     if (key == hw_revision) {
       let latest_fw = value.latest_fw;


### PR DESCRIPTION
The update page has a link "Other firmware versions can be found here: [link](https://github.com/arjenhiemstra/ithowifi/tree/master/compiled_firmware_files/non-cve_rev_1)" which points to the non-unified directories. 

This patch changes the link to the unified hw2 + non-cve one at https://github.com/arjenhiemstra/ithowifi/tree/master/compiled_firmware_files/unified_hw2_noncve