### PR TITLE
Add API for setting the outside temperature

### DIFF
--- a/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
+++ b/software/NRG_itho_wifi/main/webroot_source/controls_js_sources/html_api.html
@@ -255,14 +255,22 @@ Unless specified otherwise:<br>
             <td>outside_temp,temporary_outside_temp,valid_until</td>
             <td>number</td>
             <td style="text-align:center">●</td>
-            <td style="text-align:center">◌</td>
+            <td style="text-align:center">●</td>
         </tr>
         <tr>
-            <td colspan="6">Comments:<br><em>With this command an outside temperature can be send to a WPU. Unset values
-                    will default to 0. <b>valid_until</b> = epoch now + valid time. <b>temporary_outside_temp</b> will
-                    be used by the WPU during this valid time. After the valid time has
-                    passed it will fallback to <b>outside_temp</b>.
-                </em></td>
+            <td colspan="6">
+              Comments:<br>
+              <em>
+                With this command an outside temperature can be send to a WPU. Unset values
+                will default to 0. <b>valid_until</b> = epoch now + valid time. <b>temporary_outside_temp</b> will
+                be used by the WPU during this valid time. After the valid time has
+                passed it will fallback to <b>outside_temp</b>.
+              </em>
+              <br><br>
+              <em>
+                The web API only supports the <b>outside_temp</b> setting.
+              </em>
+            </td>
         </tr>
         <tr>
             <td>manual control</td>


### PR DESCRIPTION
This adds support to V2 of the API to set the outside temperature of an Itho WPU. This allows controlling of this value without the need for a physical sensor (i.e. by using the Buienradar API).

I didn't include support for the temporary temperature value and timestamp. The use case is to have some sort of script run periodically and update the temperature according to an external source, in which case the temporary temperature value and timestamp isn't useful. If it's desired to add this anyway, I'll happily add it of course :smiley: 