### PR TITLE
Fixed autodiscover message to be consistent with preset modes.

### DIFF
--- a/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
+++ b/software/NRG_itho_wifi/main/tasks/task_mqtt.cpp
@@ -677,13 +677,13 @@ void HADiscoveryFan()
   {
     root["pr_mode_cmd_tpl"] = "{%- if value == 'Timer 10min' %}{{'timer1'}}{%- elif value == 'Timer 20min' %}{{'timer2'}}{%- elif value == 'Timer 30min' %}{{'timer3'}}{%- else %}{{value.lower()}}{%- endif -%}";
     // snprintf(pr_mode_val_tpl, sizeof(pr_mode_val_tpl), "{%%- set speed = value_json['%s'] | int %%}{%%- if speed > 219 %%}high{%%- elif speed > 119 %%}medium{%%- elif speed > 19 %%}low{%%- else %%}auto{%%- endif -%%}", actualSpeedLabel.c_str());
-    snprintf(pr_mode_val_tpl, sizeof(pr_mode_val_tpl), "{%%- set speed = value_json['%s'] | int %%}{%%- if speed > 90 %%}high{%%- elif speed > 35 %%}medium{%%- elif speed > 10 %%}low{%%- else %%}auto{%%- endif -%%}", actualSpeedLabel.c_str());
+    snprintf(pr_mode_val_tpl, sizeof(pr_mode_val_tpl), "{%%- set speed = value_json['%s'] | int %%}{%%- if speed > 90 %%}High{%%- elif speed > 35 %%}Medium{%%- elif speed > 10 %%}Low{%%- else %%}Auto{%%- endif -%%}", actualSpeedLabel.c_str());
 
     // strncpy(pr_mode_val_tpl, "{%- if value == 'Low' %}{{'low'}}{%- elif value == 'Medium' %}{{'medium'}}{%- elif value == 'High' %}{{'high'}}{%- elif value == 'Auto' %}{{'auto'}}{%- elif value == 'AutoNight' %}{{'autonight'}}{%- elif value == 'Timer 10min' %}{{'timer1'}}{%- elif value == 'Timer 20min' %}{{'timer2'}}{%- elif value == 'Timer 30min' %}{{'timer3'}}{%- endif -%}", sizeof(pr_mode_val_tpl));
   }
   else if (pr_mode_val_tpl_ver == 1)
   {
-    snprintf(pr_mode_val_tpl, sizeof(pr_mode_val_tpl), "{%%- set speed = value_json['%s'] | int %%}{%%- if speed > 90 %%}high{%%- elif speed > 35 %%}medium{%%- elif speed > 10 %%}low{%%- else %%}auto{%%- endif -%%}", actualSpeedLabel.c_str());
+    snprintf(pr_mode_val_tpl, sizeof(pr_mode_val_tpl), "{%%- set speed = value_json['%s'] | int %%}{%%- if speed > 90 %%}High{%%- elif speed > 35 %%}Medium{%%- elif speed > 10 %%}Low{%%- else %%}Auto{%%- endif -%%}", actualSpeedLabel.c_str());
   }
 
   root["pct_cmd_tpl"] = pct_cmd_tpl;         // percentage_command_template


### PR DESCRIPTION
Possible fix or workaround for #257 . This may not be in line with 'normalize keys' options. 